### PR TITLE
Strict null checks

### DIFF
--- a/foo/bar.graphql
+++ b/foo/bar.graphql
@@ -1,0 +1,7 @@
+query foo {
+    foo
+    {
+        bar
+        foobar
+    }
+}

--- a/foo/baz.graphql
+++ b/foo/baz.graphql
@@ -1,0 +1,7 @@
+query foo {
+    faz
+    {
+        baz
+        fazbaz
+    }
+}

--- a/package.json
+++ b/package.json
@@ -1,54 +1,55 @@
 {
-  "name": "persistgraphql",
-  "version": "0.3.1",
-  "description": "A build tool for GraphQL projects.",
-  "main": "lib/index.js",
-  "scripts": {
-    "pretest": "npm run compile",
-    "test": "mocha --reporter spec --full-trace lib/test/tests.js",
-    "posttest": "npm run lint",
-    "compile": "tsc",
-    "lint": "tslint -c tslint.json test/**/*.ts; tslint src/**/*.ts"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Poincare/apollo-query-whitelisting.git"
-  },
-  "author": "Dhaivat Pandya",
-  "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/Poincare/persistgraphql/issues"
-  },
-  "homepage": "https://github.com/Poincare/persistgraphql#readme",
-  "bin": {
-    "persistgraphql": "./bin/persistgraphql"
-  },
-  "dependencies": {
-    "apollo-client": "^1.1",
-    "graphql": "^0.9.4",
-    "graphql-tag": "^2.0.0",
-    "lodash": "^4.17.4",
-    "whatwg-fetch": "^2.0.3",
-    "yargs": "^7.1.0"
-  },
-  "devDependencies": {
-    "@types/chai": "^3.5.1",
-    "@types/express": "^4.0.35",
-    "@types/lodash": "^4.14.63",
-    "@types/mocha": "^2.2.41",
-    "@types/node": "^7.0.14",
-    "@types/yargs": "^6.6.0",
-    "chai": "^3.5.0",
-    "es6-promise": "^4.1.0",
-    "fetch-mock": "^5.10.0",
-    "isomorphic-fetch": "^2.2.1",
-    "mocha": "^3.3.0",
-    "source-map-support": "^0.4.15",
-    "tslint": "^5.1.0",
-    "typescript": "^2.3.1"
-  },
-  "optionalDependencies": {
-    "@types/graphql": "^0.9.0",
-    "@types/isomorphic-fetch": "0.0.34"
-  }
+    "name": "persistgraphql",
+    "version": "0.3.1",
+    "description": "A build tool for GraphQL projects.",
+    "main": "lib/index.js",
+    "scripts": {
+        "start": "node ./bin/persistgraphql foo",
+        "pretest": "npm run compile",
+        "test": "mocha --reporter spec --full-trace lib/test/tests.js",
+        "posttest": "npm run lint",
+        "compile": "tsc",
+        "lint": "tslint -c tslint.json test/**/*.ts; tslint src/**/*.ts"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/Poincare/apollo-query-whitelisting.git"
+    },
+    "author": "Dhaivat Pandya",
+    "license": "MIT",
+    "bugs": {
+        "url": "https://github.com/Poincare/persistgraphql/issues"
+    },
+    "homepage": "https://github.com/Poincare/persistgraphql#readme",
+    "bin": {
+        "persistgraphql": "./bin/persistgraphql"
+    },
+    "dependencies": {
+        "apollo-client": "^1.1",
+        "graphql": "^0.9.4",
+        "graphql-tag": "^2.0.0",
+        "lodash": "^4.17.4",
+        "whatwg-fetch": "^2.0.3",
+        "yargs": "^7.1.0"
+    },
+    "devDependencies": {
+        "@types/chai": "^3.5.1",
+        "@types/express": "^4.0.35",
+        "@types/lodash": "^4.14.63",
+        "@types/mocha": "^2.2.41",
+        "@types/node": "^7.0.14",
+        "@types/yargs": "^6.6.0",
+        "chai": "^3.5.0",
+        "es6-promise": "^4.1.0",
+        "fetch-mock": "^5.10.0",
+        "isomorphic-fetch": "^2.2.1",
+        "mocha": "^3.3.0",
+        "source-map-support": "^0.4.15",
+        "tslint": "^5.1.0",
+        "typescript": "^2.3.1"
+    },
+    "optionalDependencies": {
+        "@types/graphql": "^0.9.0",
+        "@types/isomorphic-fetch": "0.0.34"
+    }
 }

--- a/src/ExtractGQL.ts
+++ b/src/ExtractGQL.ts
@@ -47,7 +47,7 @@ export type ExtractGQLOptions = {
   queryTransformers?: QueryTransformer[],
   extension?: string,
   inJsCode?: boolean,
-}
+};
 
 export class ExtractGQL {
   public inputFilePath: string;
@@ -138,7 +138,7 @@ export class ExtractGQL {
   // Just calls getQueryDocumentKey with this.queryTransformers as its
   // set of query transformers and returns a serialization of the query.
   public getQueryDocumentKey(
-    document: DocumentNode
+    document: DocumentNode,
   ): string {
     return getQueryDocumentKey(document, this.queryTransformers);
   }
@@ -201,7 +201,7 @@ export class ExtractGQL {
             const noInterps = literalContents.map(eliminateInterpolations);
             const joined = noInterps.join('\n');
             return joined;
-          })
+          });
         } else {
           return this.readGraphQLFile(inputFile);
         }
@@ -269,7 +269,7 @@ export class ExtractGQL {
       const definitionName = (definition as (FragmentDefinitionNode | OperationDefinitionNode)).name;
       if ((isFragmentDefinition(definition) && queryFragmentNames[definitionName.value] === 1)) {
         const definitionExists = carry.findIndex(
-          (value: FragmentDefinitionNode) => value.name.value === definitionName.value
+          (value: FragmentDefinitionNode) => value.name.value === definitionName.value,
         ) !== -1;
 
         // If this definition doesn't exist yet, add it.
@@ -280,12 +280,12 @@ export class ExtractGQL {
 
       return carry;
     };
-    
+
     retDocument.definitions = document.definitions.reduce(
       reduceQueryDefinitions,
-      ([] as FragmentDefinitionNode[])
+      ([] as FragmentDefinitionNode[]),
     ).sort(sortFragmentsByName);
-    
+
     return retDocument;
   }
 
@@ -332,7 +332,7 @@ export interface YArgsv {
 export const main = (argv: YArgsv) => {
   // These are the unhypenated arguments that yargs does not process
   // further.
-  const args: string[] = argv._
+  const args: string[] = argv._;
   let inputFilePath: string;
   let outputFilePath: string;
   const queryTransformers: QueryTransformer[] = [];

--- a/src/common.ts
+++ b/src/common.ts
@@ -56,7 +56,7 @@ export function applyFragmentDefinitionSort(document: DocumentNode): DocumentNod
 // Apply queryTransformers to a query document.
 export function applyQueryTransformers(
   document: DocumentNode,
-  queryTransformers: QueryTransformer[] = []
+  queryTransformers: QueryTransformer[] = [],
 ): DocumentNode {
   let currentDocument = document;
   queryTransformers.forEach((transformer) => {
@@ -78,7 +78,7 @@ export function getQueryKey(
   };
   return print(applyQueryTransformers(
     wrappingDocument,
-    queryTransformers
+    queryTransformers,
   ).definitions[0]);
 }
 

--- a/src/extractFromAST.ts
+++ b/src/extractFromAST.ts
@@ -89,7 +89,7 @@ export function getFragmentNames(selectionSet: SelectionSetNode, document: Docum
       fragmentNames[selection.name.value] = 1;
       const innerFragmentNames = getFragmentNames(
         fragmentDefinitions[selection.name.value].selectionSet,
-        document
+        document,
       );
       fragmentNames = _.merge(fragmentNames, innerFragmentNames);
     } else if (isInlineFragment(selection) || isField(selection)) {

--- a/src/network_interface/ApolloNetworkInterface.ts
+++ b/src/network_interface/ApolloNetworkInterface.ts
@@ -58,6 +58,11 @@ export function addPersistedQueries(networkInterface: NetworkInterface, queryMap
   return Object.assign(networkInterface, {
     query: (request: Request): Promise<ExecutionResult> => {
       const queryDocument = request.query;
+
+      if (queryDocument === undefined) {
+        return Promise.reject(new Error('No query document was provided'));
+      }
+
       const queryKey = getQueryDocumentKey(queryDocument);
 
       if (!queryMap[queryKey]) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,25 +1,26 @@
 {
-  "compilerOptions": {
-    "target": "es5",
-    "module": "commonjs",
-    "lib": ["es6", "dom"],
-    "moduleResolution": "node",
-    "sourceMap": true,
-    "declaration": true,
-    "rootDir": ".",
-    "outDir": "lib",
-    "allowSyntheticDefaultImports": true,
-    "removeComments": true,
-    "noImplicitAny": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true,
-    "types": [ "mocha", "node" ]
-  },
-  "files": [
-    "typings.d.ts",
-    "src/binary.ts",
-    "test/tests.ts",
-    "fetch-mock.typings.d.ts",
-    "index.ts"
-  ]
+    "compilerOptions": {
+        "target": "es5",
+        "module": "commonjs",
+        "lib": ["es6", "dom"],
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "declaration": true,
+        "rootDir": ".",
+        "outDir": "lib",
+        "allowSyntheticDefaultImports": true,
+        "removeComments": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "noFallthroughCasesInSwitch": true,
+        "strictNullChecks": true,
+        "types": [ "mocha", "node" ]
+    },
+    "files": [
+        "typings.d.ts",
+        "src/binary.ts",
+        "test/tests.ts",
+        "fetch-mock.typings.d.ts",
+        "index.ts"
+    ]
 }


### PR DESCRIPTION
Handle the case when no query document is passed (assuming an error should be thrown).

Also enabled `strictNullChecks` to ensure comptibility with this compiler flag.