### PR TITLE
Add hash_ids flag to override default integer values

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ npm install --save persistgraphql
 The build tool binary is called `persistgraphql`. Running it with no other arguments should give:
 
 ```
-Usage: persistgraphql input_file [output file] [--add_typename]
+Usage: persistgraphql input_file [output file] [--add_typename] [--hash_ids]
 ```
 
 It can be called on a file containing GraphQL query definitions with extension `.graphql`:
@@ -48,6 +48,14 @@ persistgraphql index.ts output.json
 ## Adding Typenames to Extracted Queries
 
 It can also take the `--add_typename` flag which will apply a query transformation to the query documents, adding the `__typename` field at every level of the query. You must pass this option if your client code uses this query transformation.
+
+```
+persistgraphql src/  --hash_ids
+```
+
+## Using a hash of the query as an ID to allow scaling for multiple clients
+
+Use the optional `hash_ids` flag to substitute a `sha512` hash of the query as the map value rather then the default which is an incremental integer. This will avoid ID collisions for multiple clients using the same server.
 
 ```
 persistgraphql src/ --add_typename

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "apollo-client": "^1.1",
     "graphql": "^0.9.4",
     "graphql-tag": "^2.0.0",
+    "hasha": "^3.0.0",
     "lodash": "^4.17.4",
     "whatwg-fetch": "^2.0.3",
     "yargs": "^7.1.0"

--- a/test/network_interface/ApolloNetworkInterface.ts
+++ b/test/network_interface/ApolloNetworkInterface.ts
@@ -1,3 +1,4 @@
+import hasha = require('hasha');
 import * as chai from 'chai';
 const { assert } = chai;
 
@@ -87,6 +88,34 @@ describe('PersistedQueryNetworkInterface', () => {
       assert(err);
       assert.include(err.message, 'Could not find');
       done();
+    });
+  });
+
+  describe('Using --hash_ids', () => {
+    const egql = new ExtractGQL({ hashIds: true, inputFilePath: 'nothing' });
+    const queriesDocument = gql`
+    query getAuthor {
+      author {
+        firstName
+        lastName
+      }
+    }
+    query getHouse {
+      house {
+        address
+      }
+    }
+    `;
+    const queryMap = egql.createMapFromDocument(queriesDocument);
+    const keys = Object.keys(queryMap);
+
+    it('should use a hash of the query as the value if --hash_ids is true', () => {
+        assert.equal(queryMap[keys[0]], hasha(keys[0]));
+        assert.equal(queryMap[keys[1]], hasha(keys[1]));
+    });
+
+    it('should not use an integer as the value if --hash_ids is true', () => {
+        assert.notEqual(queryMap[keys[0]], 1);
     });
   });
 
@@ -376,7 +405,7 @@ describe('addPersistedQueries', () => {
     const networkInterface = new GenericNetworkInterface();
     addPersistedQueries(networkInterface, queryMap);
     const expectedId = queryMap[getQueryDocumentKey(request.query)];
-    return networkInterface.query(request).then((persistedQuery: persistedQueryType) => {
+    return networkInterface.query(request).then((persistedQuery: any) => {
       const id = persistedQuery.id;
       const variables = persistedQuery.variables;
       const operationName = persistedQuery.operationName;

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -18,3 +18,8 @@ declare module 'deep-assign' {
   function deepAssign(...objects: any[]): any;
   export = deepAssign;
 }
+
+declare module 'hasha' {
+  function hasha(...objects: any[]): any;
+  export = hasha;
+}


### PR DESCRIPTION
When experimenting with using persisted queries, I found that trying have multiple clients caused potential query ID collisions due to the use of incremental integers as IDs.

This adds the option to use a hash of the query as the ID to allow multiple query maps to be combined and used on the server.