### PR TITLE
Fixed error being caused when file has no gql tags

### DIFF
--- a/src/ExtractGQL.ts
+++ b/src/ExtractGQL.ts
@@ -239,7 +239,7 @@ export class ExtractGQL {
             });
 
             Promise.all(promises).then((queryStrings: string[]) => {
-              resolve(queryStrings.reduce((x, y) => x + y));
+              resolve(queryStrings.reduce((x, y) => x + y, ''));
             });
           });
         } else {

--- a/test/fixtures/no_queries/empty_folder/test.txt
+++ b/test/fixtures/no_queries/empty_folder/test.txt
@@ -1,0 +1,1 @@
+This is just a random file.

--- a/test/fixtures/no_queries/single_query/queries.graphql
+++ b/test/fixtures/no_queries/single_query/queries.graphql
@@ -1,0 +1,13 @@
+query {
+  author {
+    firstName
+    lastName
+  }
+}
+
+query otherQuery {
+  person {
+    firstName
+    lastName
+  }
+}

--- a/test/index.ts
+++ b/test/index.ts
@@ -417,6 +417,13 @@ describe('ExtractGQL', () => {
       });
     });
 
+    it('should process a directory with no graphql files', (done) => {
+      egql.processInputPath('./test/fixtures/no_queries').then((result: OutputMap) => {
+        assert.equal(Object.keys(result).length, 2);
+        done();
+      });
+    });
+
     it('should process a file with a fragment reference to a different file', () => {
       const expectedQuery = gql`
         query {

--- a/test/output_tests/output.graphql
+++ b/test/output_tests/output.graphql
@@ -1,1 +1,1 @@
-{"{\n  author {\n    firstName\n    lastName\n  }\n}\n":9,"query otherQuery {\n  person {\n    firstName\n    lastName\n  }\n}\n":10}
+{"{\n  author {\n    firstName\n    lastName\n  }\n}\n":11,"query otherQuery {\n  person {\n    firstName\n    lastName\n  }\n}\n":12}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "es5",
     "module": "commonjs",
-    "lib": ["es6", "dom"],
+    "lib": ["es6", "dom", "esnext.asynciterable"],
     "moduleResolution": "node",
     "sourceMap": true,
     "declaration": true,


### PR DESCRIPTION
On some computers, an error is caused when there is a folder with no gql tag. The error has something to do with the reduce function having no starting value.  Adding a starting value fixed the issue users were having. This fixes issue #32 