### PR TITLE
Adding ability to process js, graphql, and other arbitrary file types (e.g. .gql)

### DIFF
--- a/src/ExtractGQL.ts
+++ b/src/ExtractGQL.ts
@@ -61,7 +61,7 @@ export class ExtractGQL {
   public queryTransformers: QueryTransformer[] = [];
 
   // The file extension to load queries from
-  public extension: string;
+  public extension: Array<string> = ['graphql'];
 
   // Whether to look for standalone .graphql files or template literals in JavaScript code
   public inJsCode: boolean = false;
@@ -109,13 +109,13 @@ export class ExtractGQL {
     inputFilePath,
     outputFilePath = 'extracted_queries.json',
     queryTransformers = [],
-    extension = 'graphql',
+    extension = '',
     inJsCode = false,
   }: ExtractGQLOptions) {
     this.inputFilePath = inputFilePath;
     this.outputFilePath = outputFilePath;
     this.queryTransformers = queryTransformers;
-    this.extension = extension;
+    this.extension = this.extension.concat(extension.split(',').map(e => e.trim()))
     this.inJsCode = inJsCode;
   }
 
@@ -193,8 +193,8 @@ export class ExtractGQL {
     return Promise.resolve().then(() => {
       const extension = ExtractGQL.getFileExtension(inputFile);
 
-      if (extension === this.extension) {
-        if (this.inJsCode) {
+      if (this.extension.indexOf(extension) > -1) {
+        if (this.inJsCode && extension === 'js') {
           // Read from a JS file
           return ExtractGQL.readFile(inputFile).then((result) => {
             const literalContents = findTaggedTemplateLiteralsInJS(result, this.literalTag);

--- a/test/fixtures/arbitrary_filetypes/code.js
+++ b/test/fixtures/arbitrary_filetypes/code.js
@@ -1,0 +1,14 @@
+import firstName from './fragment.gql';
+import lastName from './fragment.graphql';
+
+const query = gql`
+query {
+  author {
+    ...firstName
+    ...lastName
+  }
+}
+
+${firstName}
+${lastName}
+`;

--- a/test/fixtures/arbitrary_filetypes/fragment.gql
+++ b/test/fixtures/arbitrary_filetypes/fragment.gql
@@ -1,0 +1,3 @@
+fragment firstName on Author {
+  firstName
+}

--- a/test/fixtures/arbitrary_filetypes/fragment.graphql
+++ b/test/fixtures/arbitrary_filetypes/fragment.graphql
@@ -1,0 +1,3 @@
+fragment lastName on Author {
+  lastName
+}

--- a/test/fixtures/multiple_filetypes/code.js
+++ b/test/fixtures/multiple_filetypes/code.js
@@ -1,0 +1,19 @@
+import lastName from './fragment.graphql';
+
+const frag = gql`
+fragment firstName on Author {
+  firstName
+}
+`;
+
+const query = gql`
+query {
+  author {
+    ...firstName
+    ...lastName
+  }
+}
+
+${frag}
+${lastName}
+`;

--- a/test/fixtures/multiple_filetypes/fragment.graphql
+++ b/test/fixtures/multiple_filetypes/fragment.graphql
@@ -1,0 +1,3 @@
+fragment lastName on Author {
+  lastName
+}

--- a/test/index.ts
+++ b/test/index.ts
@@ -446,6 +446,74 @@ describe('ExtractGQL', () => {
         );
       });
     });
+    
+    it('should process both a JS file and a graphql file', () => {
+      const expectedQuery = gql`
+        query {
+          author {
+            ...firstName
+            ...lastName
+          }
+        }
+        fragment firstName on Author {
+          firstName
+        }
+        fragment lastName on Author {
+          lastName
+        }
+        `;
+  
+      const jsEgql = new ExtractGQL({
+        inputFilePath: 'idk',
+        extension: 'js',
+        inJsCode: true,
+        outputFilePath: 'idk',
+      });
+  
+      return jsEgql.processInputPath('./test/fixtures/multiple_filetypes')
+        .then((result: OutputMap) => {
+          const keys = Object.keys(result);
+          assert.equal(keys.length, 1);
+          assert.equal(
+            keys[0],
+            print(expectedQuery)
+          );
+        });
+    });
+
+    it('should process arbitrary file extensions', () => {
+      const expectedQuery = gql`
+        query {
+          author {
+            ...firstName
+            ...lastName
+          }
+        }
+        fragment firstName on Author {
+          firstName
+        }
+        fragment lastName on Author {
+          lastName
+        }
+        `;
+  
+      const jsEgql = new ExtractGQL({
+        inputFilePath: 'idk',
+        extension: 'js,gql',
+        inJsCode: true,
+        outputFilePath: 'idk',
+      });
+  
+      return jsEgql.processInputPath('./test/fixtures/arbitrary_filetypes')
+        .then((result: OutputMap) => {
+          const keys = Object.keys(result);
+          assert.equal(keys.length, 1);
+          assert.equal(
+            keys[0],
+            print(expectedQuery)
+          );
+        });
+    });
 
     it('should process a JS file with queries', () => {
       const expectedQuery = gql`


### PR DESCRIPTION
`extension` property / argument now supports multiple file types.

This allows users to execute `persistgraphql` in environments that utilize the `gql` tagged template literal, `.graphql` files, `.gql` files, and any arbitrary extension that consumers have defined for graphql files.

Specifically, the `persistgraphql-webpack-plugin` defines a loader for `.graphql|.gql` files, which was my original aim to support.

Fixes [#50](https://github.com/apollographql/persistgraphql/issues/50)
