### PR TITLE
Be nice(r) when no arguments given

### DIFF
--- a/src/ExtractGQL.ts
+++ b/src/ExtractGQL.ts
@@ -342,6 +342,7 @@ export const main = (argv: YArgsv) => {
 
   if (args.length < 1) {
     console.log('Usage: persistgraphql input_file [output_file]');
+    process.exit(1);
   } else if (args.length === 1) {
     inputFilePath = args[0];
   } else {

--- a/src/network_interface/ApolloNetworkInterface.ts
+++ b/src/network_interface/ApolloNetworkInterface.ts
@@ -58,6 +58,11 @@ export function addPersistedQueries(networkInterface: NetworkInterface, queryMap
   return Object.assign(networkInterface, {
     query: (request: Request): Promise<ExecutionResult> => {
       const queryDocument = request.query;
+
+      if (queryDocument === undefined) {
+        return Promise.reject(new Error('No query document was provided'));
+      }
+
       const queryKey = getQueryDocumentKey(queryDocument);
 
       if (!queryMap[queryKey]) {


### PR DESCRIPTION
Having a standalone install `persistgraphql` gives a stack dump

> Usage: persistgraphql input_file [output_file]
(node:46389) UnhandledPromiseRejectionWarning: TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be one of type string, Buffer, or URL. Received type undefined
    at Object.fs.stat (fs.js:884:3)
    at /usr/local/lib/node_modules/persistgraphql/lib/src/ExtractGQL.js:45:16
    at new Promise (<anonymous>)
    at Function.ExtractGQL.isDirectory (/usr/local/lib/node_modules/persistgraphql/lib/src/ExtractGQL.js:44:16)
    at /usr/local/lib/node_modules/persistgraphql/lib/src/ExtractGQL.js:139:24
    at new Promise (<anonymous>)
    at ExtractGQL.readInputPath (/usr/local/lib/node_modules/persistgraphql/lib/src/ExtractGQL.js:138:16)
    at /usr/local/lib/node_modules/persistgraphql/lib/src/ExtractGQL.js:129:19
    at new Promise (<anonymous>)
    at ExtractGQL.processInputPath (/usr/local/lib/node_modules/persistgraphql/lib/src/ExtractGQL.js:128:16)

With the patch

```bash
persistgraphql && echo Success not gona happen
persistgraphql || echo Failed
```

which is as expected.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] has-reproduction
- [ ] feature
- [ ] blocking
- [ ] good first review

To add a label not listed above, simply place `/label another-label-name` on a line by itself.

/label standalone

-->