### PR TITLE
Return empty map for empty doc (instead of error)

### DIFF
--- a/src/ExtractGQL.ts
+++ b/src/ExtractGQL.ts
@@ -174,6 +174,10 @@ export class ExtractGQL {
 
   // Creates an OutputMap from an array of GraphQL documents read as strings.
   public createOutputMapFromString(docString: string): OutputMap {
+    // Graphql can't parse empty documents (e.g. from js files with no `gql` tags);
+    // return an empty output map.
+    if (!docString) return {};
+
     const doc = parse(docString);
     const docMap = separateOperations(doc);
 


### PR DESCRIPTION
Graphql can't parse empty documents (e.g. from js files with no `gql` tags); return an empty OutputMap in these cases instead of failing. Example:

```bash
# File with no `gql` tags:
yarn run persistgraphql --js --extension=js src/components/App.js
```

leads to

```console
Unable to process input path src/components/App.js. Error message:
Syntax Error GraphQL request (1:1) Unexpected <EOF>

1:
   ^
```

This makes it impossible for me to recursively analyze a directory (e.g. `src/`) because there are undoubtedly going to be some .js files in that directory without any `gql` tags.

Note: This is a similar error to https://github.com/apollographql/persistgraphql/pull/48 and https://github.com/apollographql/persistgraphql/issues/20 but seemingly a different cause. This was also merged recently but seemingly didn't fix the issue in all cases: https://github.com/apollographql/persistgraphql/pull/48.